### PR TITLE
feat: basic implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ Pulumi.*.yaml
 
 ###Block(extras)
 testDir
+tilt_modules
 ###EndBlock(extras)

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,32 @@
+# -*- mode: Python -*-
+
+# For more on Extensions, see: https://docs.tilt.dev/extensions.html
+load('ext://restart_process', 'docker_build_with_restart')
+
+allow_k8s_contexts('gke_outreach-docker_us-west1_loft-dev-us-west1')
+
+local_resource(
+  'compile',
+  'make build GOOS=linux GOARCH=amd64 CGO_ENABLED=0',
+  deps=['./cmd', './pkg', './internal'],
+)
+
+docker_build_with_restart(
+  'gcr.io/outreach-docker/vcluster-fs-syncer',
+  '.',
+  entrypoint=['/app/bin/vcluster-fs-syncer'],
+  dockerfile='deployments/vcluster-fs-syncer/Dockerfile.dev',
+  only=[
+    './bin',
+    './deployments/vcluster-fs-syncer',
+  ],
+  ssh='default',
+  live_update=[
+    sync('./bin', '/app/bin'),
+  ],
+)
+
+templated_yaml = local('./scripts/shell-wrapper.sh deploy-to-dev.sh show')
+k8s_yaml(templated_yaml)
+k8s_resource('vcluster-fs-syncer', port_forwards=8080,
+             resource_deps=['compile'])

--- a/cmd/vcluster-fs-syncer/main.go
+++ b/cmd/vcluster-fs-syncer/main.go
@@ -114,13 +114,6 @@ func main() { //nolint: funlen
 		})
 	}
 	if err := g.Wait(); err != nil {
-		// This is stop gap for now to ensure we actually stop the syncer
-		// long term need to see why Close() isn't being called properly above.
-		log.Info(ctx, "stopping syncer")
-		if err := sync.Close(ctx); err != nil {
-			log.Warn(ctx, "failed to stop syncer")
-		}
-
 		log.Info(ctx, "stopping service", events.NewErrorInfo(err))
 	}
 }

--- a/cmd/vcluster-fs-syncer/main.go
+++ b/cmd/vcluster-fs-syncer/main.go
@@ -84,6 +84,7 @@ func main() { //nolint: funlen
 
 	// Place any code for your service to run before registering service activities in this block
 	///Block(initialization)
+	sync := &vcluster_fs_syncer.SyncerService{}
 	///EndBlock(initialization)
 
 	acts := []serviceActivity{
@@ -91,7 +92,7 @@ func main() { //nolint: funlen
 		&vcluster_fs_syncer.HTTPService{},
 		// Place any additional ServiceActivities that your service has built here to have them handled automatically
 		///Block(services)
-		&vcluster_fs_syncer.SyncerService{},
+		sync,
 		///EndBlock(services)
 	}
 
@@ -113,6 +114,13 @@ func main() { //nolint: funlen
 		})
 	}
 	if err := g.Wait(); err != nil {
-		log.Info(ctx, "Closing down service due to", events.NewErrorInfo(err))
+		// This is stop gap for now to ensure we actually stop the syncer
+		// long term need to see why Close() isn't being called properly above.
+		log.Info(ctx, "stopping syncer")
+		if err := sync.Close(ctx); err != nil {
+			log.Warn(ctx, "failed to stop syncer")
+		}
+
+		log.Info(ctx, "stopping service", events.NewErrorInfo(err))
 	}
 }

--- a/deployments/vcluster-fs-syncer/Dockerfile
+++ b/deployments/vcluster-fs-syncer/Dockerfile
@@ -33,5 +33,3 @@ ENV ZONEINFO=/zoneinfo.zip
 ###EndBlock(afterBuild)
 
 COPY --from=builder /src/bin/vcluster-fs-syncer /usr/local/bin/vcluster-fs-syncer
-
-USER systemuser

--- a/deployments/vcluster-fs-syncer/Dockerfile.dev
+++ b/deployments/vcluster-fs-syncer/Dockerfile.dev
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.0-experimental
+# This Dockerfile is used by Tilt currently. It should
+# be kept in sync with the production one.
+FROM gcr.io/outreach-docker/golang:1.15.2 as builder
+FROM gcr.io/outreach-docker/alpine:3.12
+WORKDIR "/app/bin"
+ENTRYPOINT ["/app/bin/vcluster-fs-syncer"]
+
+# Add timezone information.
+COPY --from=builder /usr/local/go/lib/time/zoneinfo.zip /zoneinfo.zip
+ENV ZONEINFO=/zoneinfo.zip
+
+###Block(afterBuild)
+###EndBlock(afterBuild)
+
+COPY ./bin/vcluster-fs-syncer /app/bin/vcluster-fs-syncer

--- a/deployments/vcluster-fs-syncer/vcluster-fs-syncer.config.jsonnet
+++ b/deployments/vcluster-fs-syncer/vcluster-fs-syncer.config.jsonnet
@@ -37,18 +37,6 @@ local configurationOverride = {
           ///EndBlock(developmentConfig)
         },
       },
-      fflags_configmap+: {
-        data_+: {
-          flagsToAdd+: custom_attributes,
-        },
-      },
-      trace_configmap+: {
-        data_+: {
-          GlobalTags+: {
-            DevEmail: devEmail,
-          },
-        },
-      },
     },
     ///Block(environmentConfig)
     ///EndBlock(environmentConfig)
@@ -65,6 +53,8 @@ local configurationOverride = {
     ///Block(defaultConfig)
     configmap+: {
       data_+:: {
+        fromPath: '/host_mnt/kubelet/pods',
+        toPath: '/host_mnt/loft',
       },
     },
     ///EndBlock(defaultConfig)

--- a/deployments/vcluster-fs-syncer/vcluster-fs-syncer.override.jsonnet
+++ b/deployments/vcluster-fs-syncer/vcluster-fs-syncer.override.jsonnet
@@ -29,6 +29,10 @@ local objects = {
             default+: {
               securityContext: {
                 privileged: true,
+                capabilities: {
+                  add: ["SYS_ADMIN"]
+                },
+                allowPrivilegeEscalation: true
               },
               volumeMounts_+:: {
                 'var-lib': {

--- a/deployments/vcluster-fs-syncer/vcluster-fs-syncer.override.jsonnet
+++ b/deployments/vcluster-fs-syncer/vcluster-fs-syncer.override.jsonnet
@@ -22,24 +22,65 @@ local objects = {
     kind: 'DaemonSet',
     spec+: {
       replicas: null,
+      template+: {
+        spec+: {
+          serviceAccountName: $.svc_account.metadata.name,
+          containers_+:: {
+            default+: {
+              securityContext: {
+                privileged: true,
+              },
+              volumeMounts_+:: {
+                'var-lib': {
+                  mountPath: '/host_mnt',
+
+                  // Enables our bind mounts from syncer to be reflected
+                  // on the host
+                  mountPropagation: 'Bidirectional',
+                },
+              },
+            },
+          },
+          volumes_+:: {
+            'var-lib': {
+              hostPath: {
+                path: '/var/lib',
+                type: 'Directory',
+              },
+            },
+          },
+        },
+      },
     },
   },
-  pdb: null,
+  svc_account: ok.ServiceAccount(name+'-syncer', namespace) {},
+  role: ok.ClusterRole(name+'-syncer', namespace) {
+    rules: [
+      {
+        apiGroups: [
+          ""
+        ],
+        resources: [
+          "pods"
+        ],
+        verbs: [
+          "get",
+          "list",
+          "watch"
+        ]
+      },
+    ],
+  },
+  rolebinding: ok.ClusterRoleBinding(name+"-syncer", namespace) {
+    roleRef_:: $.role,
+    subjects_:: [$.svc_account],
+  },
   ///EndBlock(override)
 };
 
 // All objects in this block will only be created in a dev cluster.
 // Ideally you'd put VaultSecrets here, or something else.
 local dev_objects = {
-  service+: {
-    metadata+: {
-      annotations+: {
-        // Allow everyone AdminGW gRPCUI access in dev environment
-        'outreach.io/admingw-allow-grpc-1000000': '.* Everyone',
-      },
-    },
-  },
-
   ///Block(devoverride)
   ///EndBlock(devoverride)
 };

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/getoutreach/gobox v1.13.0
 	github.com/getoutreach/httpx v1.4.0
 	github.com/google/uuid v1.2.0
+	github.com/kr/fs v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	go.uber.org/automaxprocs v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/getoutreach/gobox v1.13.0
 	github.com/getoutreach/httpx v1.4.0
 	github.com/google/uuid v1.2.0
-	github.com/kr/fs v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	go.uber.org/automaxprocs v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -564,6 +564,7 @@ github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/go.sum
+++ b/go.sum
@@ -819,8 +819,6 @@ github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
-github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/go.sum
+++ b/go.sum
@@ -819,6 +819,8 @@ github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/internal/syncer/mount.go
+++ b/internal/syncer/mount.go
@@ -48,10 +48,5 @@ func bindMount(from, to string) error {
 }
 
 func unmountBind(dir string) error {
-	absDir, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		return fmt.Errorf("Could not resolve symlink for dir %v", dir)
-	}
-
-	return syscall.Unmount(absDir, syscall.MNT_DETACH|UmountNoFollow)
+	return syscall.Unmount(dir, syscall.MNT_DETACH|UmountNoFollow)
 }

--- a/internal/syncer/mount.go
+++ b/internal/syncer/mount.go
@@ -27,7 +27,7 @@ func bindMount(from, to string) error {
 	}
 
 	if err := os.Mkdir(to, fromSt.Mode()); os.IsExist(err) {
-		err = syscall.Unmount(absFrom, syscall.MNT_DETACH|UmountNoFollow)
+		err = unmountBind(from)
 		if err != nil {
 			// TODO: better way to handle this?
 			logrus.WithError(err).Warn("failed to unmount dir for remount")
@@ -45,4 +45,13 @@ func bindMount(from, to string) error {
 	}
 
 	return nil
+}
+
+func unmountBind(dir string) error {
+	absDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return fmt.Errorf("Could not resolve symlink for dir %v", dir)
+	}
+
+	return syscall.Unmount(absDir, syscall.MNT_DETACH|UmountNoFollow)
 }

--- a/internal/syncer/mount.go
+++ b/internal/syncer/mount.go
@@ -48,5 +48,10 @@ func bindMount(from, to string) error {
 }
 
 func unmountBind(dir string) error {
-	return syscall.Unmount(dir, syscall.MNT_DETACH|UmountNoFollow)
+	err := syscall.Unmount(dir, syscall.MNT_DETACH|UmountNoFollow)
+	if err != nil {
+		return errors.Wrapf(err, "failed to unmount %s", dir)
+	}
+
+	return os.Remove(dir)
 }

--- a/internal/syncer/mount.go
+++ b/internal/syncer/mount.go
@@ -1,0 +1,48 @@
+package syncer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// Sadly golang/sys doesn't have UmountNoFollow although it's there since Linux 2.6.34
+const UmountNoFollow = 0x8
+
+// bindMount bind mounts from onto to, thus files written from to go into from
+// and vice-versa
+func bindMount(from, to string) error {
+	absFrom, err := filepath.EvalSymlinks(from)
+	if err != nil {
+		return fmt.Errorf("Could not resolve symlink for from %v", from)
+	}
+
+	fromSt, err := os.Stat(from)
+	if err != nil {
+		return errors.Wrap(err, "failed to stat from")
+	}
+
+	if err := os.Mkdir(to, fromSt.Mode()); os.IsExist(err) {
+		err = syscall.Unmount(absFrom, syscall.MNT_DETACH|UmountNoFollow)
+		if err != nil {
+			// TODO: better way to handle this?
+			logrus.WithError(err).Warn("failed to unmount dir for remount")
+		}
+	} else if err != nil {
+		return errors.Wrap(err, "failed to create to dir")
+	}
+
+	if err := syscall.Mount(absFrom, to, "bind", syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("Could not bind mount %v to %v: %v", absFrom, to, err)
+	}
+
+	if err := syscall.Mount("none", to, "", syscall.MS_SHARED, ""); err != nil {
+		return fmt.Errorf("Could not make mount point %v %s: %v", to, syscall.MS_SHARED, err)
+	}
+
+	return nil
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -351,10 +351,9 @@ func (s *Syncer) Close() error {
 			return nil
 		}
 
-		bindPath := filepath.Join(s.toPath, path)
-		s.log.WithField("pod.path", s.toPath).Info("cleaning up mount")
+		s.log.WithField("pod.path", path).Info("cleaning up mount")
 
-		err = unmountBind(bindPath)
+		err = unmountBind(path)
 		if err != nil {
 			s.log.WithError(err).WithField("pod.path", s.toPath).Warn("failed to remove bind mount")
 		}

--- a/internal/vcluster-fs-syncer/syncerservice.go
+++ b/internal/vcluster-fs-syncer/syncerservice.go
@@ -7,12 +7,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type SyncerService struct{}
+type SyncerService struct {
+	syncer *syncer.Syncer
+}
 
 func (s *SyncerService) Run(ctx context.Context, conf *Config) error {
-	return syncer.NewSyncer(conf.FromPath, conf.ToPath, logrus.New()).Start(ctx)
+	s.syncer = syncer.NewSyncer(conf.FromPath, conf.ToPath, logrus.New())
+	return s.syncer.Start(ctx)
 }
 
 func (s *SyncerService) Close(_ context.Context) error {
-	return nil
+	return s.syncer.Close()
 }


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR finalizes the implementation of the `vcluster-fs-syncer`, this works as described on discord:

> I'm watching `/var/lib/kubelet/pods` to see when a new directory is created, which corresponds to a pod UID that has been scheduled onto this node. I then lookup the UID in my informer backed cache and see if that pod corresponds to a pod in a vcluster (TL;DR k8s in k8s, but it schedules individual pods onto the host). The vcluster pods have different UIDs inside of the cluster. So, I then map `/var/lib/kubelet/pods/<uid>` to `/var/lib/loft/<vcluster-name>/kubelet/pods/<vclusterPodUID>`
> 
> The idea is that stuff that relies on /var/lib/kubelet/pods can mount that directory instead to get the pod UIDs they expect to match while still actually pointing to the real pod directory. Use case for this is velero, which uses that to do PVC restores.

<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-775]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:

<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-775]: https://outreach-io.atlassian.net/browse/DTSS-775